### PR TITLE
fix: render multiple instances of the same model

### DIFF
--- a/src/components/models/BambooBehindFence.vue
+++ b/src/components/models/BambooBehindFence.vue
@@ -6,13 +6,13 @@ const registeredForSelectingModelStore = useRegisteredForSelectingModelStore()
 
 const { nodes } = await modelLoader
 
-const model = nodes.BambooBehindFence
+const model = nodes.BambooBehindFence.clone()
 
 registeredForSelectingModelStore.register(model)
 </script>
 
 <template>
-  <primitive :object="nodes.BambooBehindFence.clone()" />
+  <primitive :object="model" />
 </template>
 
 <style scoped>

--- a/src/components/models/Bridge.vue
+++ b/src/components/models/Bridge.vue
@@ -6,13 +6,13 @@ const registeredForSelectingModelStore = useRegisteredForSelectingModelStore()
 
 const { nodes } = await modelLoader
 
-const model = nodes.Bridge
+const model = nodes.Bridge.clone()
 
 registeredForSelectingModelStore.register(model)
 </script>
 
 <template>
-  <primitive :object="nodes.Bridge.clone()" />
+  <primitive :object="model" />
 </template>
 
 <style scoped>


### PR DESCRIPTION
fixes #33 

For already loaded and parsed models the GLTF loader returns a cached version. `primitive` uses then the same model which means the single instance is unmounted and mounted again with other coordinates.
By cloning the model each component gets its own model instance.