### PR TITLE
feat: init game loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-format": "0.1.2",
     "eslint-plugin-perfectionist": "2.11.0",
     "eslint-plugin-vue": "9.23.0",
+    "eventemitter3": "5.0.1",
     "npm-run-all2": "6.2.0",
     "pinia": "2.1.7",
     "postcss": "8.4.38",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       eslint-plugin-vue:
         specifier: 9.23.0
         version: 9.23.0(eslint@8.57.0)
+      eventemitter3:
+        specifier: 5.0.1
+        version: 5.0.1
       npm-run-all2:
         specifier: 6.2.0
         version: 6.2.0
@@ -1453,6 +1456,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
@@ -4235,6 +4241,8 @@ snapshots:
   estree-walker@2.0.2: {}
 
   esutils@2.0.3: {}
+
+  eventemitter3@5.0.1: {}
 
   execa@8.0.1:
     dependencies:

--- a/src/game-logic/events/index.ts
+++ b/src/game-logic/events/index.ts
@@ -1,0 +1,7 @@
+import { EventEmitter } from 'eventemitter3'
+
+interface EventsMap {
+  game_tick: [delta_ms: number]
+}
+
+export const gameEvents = new EventEmitter<EventsMap>()

--- a/src/game-logic/index.ts
+++ b/src/game-logic/index.ts
@@ -1,0 +1,19 @@
+import { gameEvents } from '@/game-logic/events/index.js'
+
+export function startGameLoop() {
+  let raf = requestAnimationFrame(emitTick)
+
+  let lastDt: DOMHighResTimeStamp = 0
+
+  function emitTick(dt: DOMHighResTimeStamp) {
+    // We don't get the delta but the time passed since (probably) the page load.
+    const delta = dt - lastDt
+    lastDt = dt
+
+    gameEvents.emit('game_tick', delta)
+
+    raf = requestAnimationFrame(emitTick)
+  }
+
+  return () => cancelAnimationFrame(raf)
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { createPinia } from 'pinia'
 
 import App from './App.vue'
 import router from './router'
+import { startGameLoop } from '@/game-logic/index.js'
 
 const app = createApp(App)
 
@@ -12,3 +13,5 @@ app.use(createPinia())
 app.use(router)
 
 app.mount('#app')
+
+startGameLoop()


### PR DESCRIPTION
I went ahead and implemented the rudimentary "game loop". It simply emits a tick event as fast as it can with the passed milliseconds.
Interested entities can subscribe to be updated by:
```ts
import { gameEvents } from '@/game-logic/events/index.js'

gameEvents.on('game_tick', (delta) => {
  // Increase something
  // Reduce remaining building time
  // ...
})
```

I actually used `eventemitter3` which is nice to get autocompletion on events :100: 